### PR TITLE
Update LOCALSTACK_ENDPOINT to prioritise AWS_ENDPOINT_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ samlocal --help
 
 ## Change Log
 
+* v1.68.0: Support `AWS_ENDPOINT_URL` for configuring the `boto3.client` endpoint
 * v1.67.0: Patch underlying `boto3.Session.client` instead of `boto3.client`
 * v1.55.0: Fix s3 URl detection when using a nested template
 * v1.53.1: Fix logic around local URLs for ECR image repositories

--- a/bin/samlocal
+++ b/bin/samlocal
@@ -30,7 +30,8 @@ LOCALHOST_HOSTNAME = 'localhost.localstack.cloud'
 # configuration values
 EDGE_PORT = os.environ.get('EDGE_PORT') or 4566
 LOCALSTACK_HOSTNAME = os.environ.get('LOCALSTACK_HOSTNAME') or 'localhost'
-LOCALSTACK_ENDPOINT = f'http://{LOCALSTACK_HOSTNAME}:{EDGE_PORT}'
+AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
+LOCALSTACK_ENDPOINT = AWS_ENDPOINT_URL or f'http://{LOCALSTACK_HOSTNAME}:{EDGE_PORT}'
 
 
 def boto3_Session_client(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import re
 from setuptools import find_packages, setup
 
-VERSION = '1.67.0'
+VERSION = '1.68.0'
 
 # parameter variables
 install_requires = []


### PR DESCRIPTION
# Motivation

As part of LocalStack 3.0 we are allowing the use of `AWS_ENDPOINT_URL` to configure tools. This is being rolled out by AWS across their SDKs. The `boto3` SDK (used by `aws-sam-cli`) already supports this environment variable, however we are explicitly overriding the default in `aws-sam-cli-local`).

# Changes

* Accept `AWS_ENDPOINT_URL` from the environment (if specified).
