### PR TITLE
Update README with AWS_ENDPOINT_URL and deprecate old variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ samlocal --help
 
 ## Configuration
 
-* `EDGE_PORT`: Port number under which the LocalStack edge service is available (default: `4566`)
-* `LOCALSTACK_HOSTNAME`: Host under which the LocalStack edge service is available (default: `localhost`)
+* `AWS_ENDPOINT_URL`: URL at which the `boto3` client can reach LocalStack, e.g. `http://localhost.localstack.cloud:4566`
+* `EDGE_PORT`: **Deprecated** Port number under which the LocalStack edge service is available (default: `4566`)
+* `LOCALSTACK_HOSTNAME`: **Deprecated** Host under which the LocalStack edge service is available (default: `localhost`)
 
 ## Change Log
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ samlocal --help
 
 ## Configuration
 
-* `AWS_ENDPOINT_URL`: URL at which the `boto3` client can reach LocalStack, e.g. `http://localhost.localstack.cloud:4566`
+* `AWS_ENDPOINT_URL`: URL at which the `boto3` client can reach LocalStack, e.g. `http://localhost.localstack.cloud:4566` (default: `http://localhost:4566`)
 * `EDGE_PORT`: **Deprecated** Port number under which the LocalStack edge service is available (default: `4566`)
 * `LOCALSTACK_HOSTNAME`: **Deprecated** Host under which the LocalStack edge service is available (default: `localhost`)
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ for line in re.split('\n', requirements):
         lib_stripped = line.split(' #')[0].strip()
         install_requires.append(lib_stripped)
 
+# get the long description from the README.md
+with open("README.md") as f:
+    long_description = f.read()
+
 
 if __name__ == '__main__':
 
@@ -24,6 +28,7 @@ if __name__ == '__main__':
         name='aws-sam-cli-local',
         version=VERSION,
         description='Simple wrapper around AWS SAM CLI for use with LocalStack',
+        long_description=long_description,
         author='LocalStack Team',
         author_email='info@localstack.cloud',
         url='https://github.com/localstack/aws-sam-cli-local',


### PR DESCRIPTION
# Motivation

In #12 we introduced `AWS_ENDPOINT_URL` as a configuration variable for how to reach LocalStack from `samlocal`. This variable was added in the changelog, but missed from the configuration section of the documentation.

Also: the [pypi page](https://pypi.org/project/aws-sam-cli-local/) looks a little sparse.


# Changes

* Add `AWS_ENDPOINT_URL` to the configuration variables
* Deprecate the previous two variables `EDGE_PORT` and `LOCALSTACK_HOSTNAME`
* Add a long description field to the package so that it looks nicer on PyPI (this will be picked up with the next version bump)
