### PR TITLE
Accept AWS conform ECR URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ samlocal --help
 
 ## Change Log
 
+* v1.70.0: Fix regex pattern to detect ECR URLs with dashes
 * v1.69.0: Fix repo related cli options and add support to Lambdas with `Image` type
 * v1.68.0: Support `AWS_ENDPOINT_URL` for configuring the `boto3.client` endpoint
 * v1.67.0: Patch underlying `boto3.Session.client` instead of `boto3.client`

--- a/bin/samlocal
+++ b/bin/samlocal
@@ -74,7 +74,7 @@ GuidedContext.prompt_image_repository = prompt_image_repository
 
 def is_ecr_url(url: str) -> bool:
     result = is_ecr_url_orig(url)
-    ecr_url_regex = r"[a-zA-Z0-9_.:]+/[a-zA-Z0-9_/-]+"
+    ecr_url_regex = r"[a-zA-Z0-9_.:-]+/[a-zA-Z0-9_/-]+"
     return result or bool(re.match(ecr_url_regex, url or ''))
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import re
 from setuptools import find_packages, setup
 
-VERSION = '1.69.0'
+VERSION = '1.70.0'
 
 # parameter variables
 install_requires = []


### PR DESCRIPTION
#Motivation

LocalStack 3.4 introduced the new `ECR_ENDPOINT_STRATEGY` which defaults to `domain`.
By that, the previously used ECR repository URIs (`localhost.localstack.cloud:4510/sample`) started to fail as LocalStack was expecting the AWS pattern (`000000000000.dkr.ecr.us-east-1.localhost.localstack.cloud:4566/sample`), however the usage of the new pattern resulted in the following error message:
```
Error: Invalid value for '--image-repository': Invalid Image Repository ECR URI: image_repository = 000000000000.dkr.ecr.us-east-1.localhost.localstack.cloud:4566/sample
```

#Changes
- fix patch's `ecr_url_regex` pattern