### PR TITLE
Fix ECR repository URL replacement for LocalStack 3.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ samlocal --help
 
 ## Change Log
 
+* v1.70.1: Fix ECR repository rewrite logic
 * v1.70.0: Fix regex pattern to detect ECR URLs with dashes
 * v1.69.0: Fix repo related cli options and add support to Lambdas with `Image` type
 * v1.68.0: Support `AWS_ENDPOINT_URL` for configuring the `boto3.client` endpoint

--- a/bin/samlocal
+++ b/bin/samlocal
@@ -92,7 +92,7 @@ def upload(self, image, resource_name):
         ecr_endpoint = get_registry_url(self)
         ecr_repo = self.ecr_repo_multi.get(resource_name)
         if ecr_repo and "amazonaws.com" in ecr_repo:
-            self.ecr_repo_multi[resource_name] = ecr_repo.replace("amazonaws.com", ecr_endpoint)
+            self.ecr_repo_multi[resource_name] = f'{ecr_endpoint}/{ecr_repo.split("/",1)[1]}'
     except (AttributeError, TypeError):
         pass
     return upload_orig(self, image, resource_name)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import re
 from setuptools import find_packages, setup
 
-VERSION = '1.70.0'
+VERSION = '1.70.1'
 
 # parameter variables
 install_requires = []


### PR DESCRIPTION
As mentioned in PR #20, LocalStack version 3.4 introduced the `ECR_ENDPOINT_STRATEGY` variable, which changed how ECR endpoints are generated. This update affected the current domain replacement logic, resulting in invalid image repository names when using LocalStack’s ECR.

For example:

- **Correct image name**:  
  `000000000000.dkr.ecr.us-east-1.amazonaws.com/sample5e8ff9bf/samplefunction757ff6efrepo`

- **Endpoint returned by LocalStack**:  
  `000000000000.dkr.ecr.us-east-1.localhost.localstack.cloud:4566/sample5e8ff9bf/samplefunction757ff6efrepo`

- **Incorrect result after the current replace**:  
  `000000000000.dkr.ecr.us-east-1.000000000000.dkr.ecr.us-east-1.localhost.localstack.cloud:4566/sample5e8ff9bf/samplefunction757ff6efrepo`

- **Expected result after replace**:  
  `000000000000.dkr.ecr.us-east-1.localhost.localstack.cloud:4566/sample5e8ff9bf/samplefunction757ff6efrepo`

This incorrect replacement causes a "repository not found" error when uploading the image to the local ECR.

This PR updates the domain replacement logic to ensure compatibility with the changes introduced in LocalStack 3.4.
