### PR TITLE
update CI to use auth token

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,9 +40,8 @@ jobs:
         python-version: "3.11"
     - name: Start LocalStack
       uses: LocalStack/setup-localstack@v0.2.5
-      with:
-        image-tag: 'latest'
-        install-awslocal: 'true'
+      env:
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     - name: Install the package
       run: |
         make setup-venv


### PR DESCRIPTION
## Motivation
With the upcoming [image consolidation](https://blog.localstack.cloud/the-road-ahead-for-localstack/), LocalStack will require an auth token to start up.
This PR updates the CI of this project to use the CI token configured as a secret for this project.

Fixes ENG-394.

## Changes
- Set `LOCALSTACK_AUTH_TOKEN` when starting LocalStack.
- Remove unnecessary default values when using `setup-localstack`.